### PR TITLE
more logging for zap

### DIFF
--- a/tasks/owasp-zap/build.sh
+++ b/tasks/owasp-zap/build.sh
@@ -1,1 +1,2 @@
 mkdir /zap/wrk
+pip3 install --no-cache-dir psutil

--- a/tasks/owasp-zap/definition.py
+++ b/tasks/owasp-zap/definition.py
@@ -1,7 +1,7 @@
 from lib.task import BaseBuildTask
 import subprocess
 import psutil
-
+import time
 
 class BuildTask(BaseBuildTask):
     def __init__(self):
@@ -18,6 +18,8 @@ class BuildTask(BaseBuildTask):
         self.logger.info(f'CPU Usage Percentage: {psutil.cpu_percent()}')
         self.logger.info(f'Memory Usage Percentage: {psutil.virtual_memory().percent}')
         self.logger.info(f'Disk usage: {disk.used} / {disk.total}')
+
+        time.sleep(3600)
 
         subprocess.run([
             'zap-baseline.py',

--- a/tasks/owasp-zap/definition.py
+++ b/tasks/owasp-zap/definition.py
@@ -17,9 +17,8 @@ class BuildTask(BaseBuildTask):
         disk = psutil.disk_usage("/")
         self.logger.info(f'CPU Usage Percentage: {psutil.cpu_percent()}')
         self.logger.info(f'Memory Usage Percentage: {psutil.virtual_memory().percent}')
+        self.logger.info(f'Memory Usage: {psutil.virtual_memory().total}')
         self.logger.info(f'Disk usage: {disk.used} / {disk.total}')
-
-        time.sleep(3600)
 
         subprocess.run([
             'zap-baseline.py',

--- a/tasks/owasp-zap/definition.py
+++ b/tasks/owasp-zap/definition.py
@@ -1,5 +1,6 @@
 from lib.task import BaseBuildTask
 import subprocess
+import psutil
 
 
 class BuildTask(BaseBuildTask):
@@ -11,6 +12,13 @@ class BuildTask(BaseBuildTask):
     def handler(self):
         """scan"""
         filename = 'report.html'
+        self.logger.info(f'Scanning {self.args["target"]}')
+
+        disk = psutil.disk_usage("/")
+        self.logger.info(f'CPU Usage Percentage: {psutil.cpu_percent()}')
+        self.logger.info(f'Memory Usage Percentage: {psutil.virtual_memory().percent}')
+        self.logger.info(f'Disk usage: {disk.used} / {disk.total}')
+
         subprocess.run([
             'zap-baseline.py',
             '-t', self.args['target'],


### PR DESCRIPTION
## Changes proposed in this pull request:

-
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

[Note the any security considerations here, or make note of why there are none]
