### PR TITLE
chore(ci): Switch to general-task and registry-image for CI jobs

### DIFF
--- a/ci/pipeline-dev.yml
+++ b/ci/pipeline-dev.yml
@@ -154,9 +154,9 @@ resources:
     source:
       aws_access_key_id: ((ecr-aws-key))
       aws_secret_access_key: ((ecr-aws-secret))
-      repository: harden-concourse-task
+      repository: general-task
       aws_region: us-gov-west-1
-      tag: ((harden-concourse-task-tag))
+      tag: latest
 
 ############################
 #  RESOURCE TYPES
@@ -178,5 +178,14 @@ resource_types:
       aws_access_key_id: ((ecr_aws_key))
       aws_secret_access_key: ((ecr_aws_secret))
       repository: github-pr-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: registry-image
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: registry-image-resource
       aws_region: us-gov-west-1
       tag: latest

--- a/ci/pipeline-staging.yml
+++ b/ci/pipeline-staging.yml
@@ -152,9 +152,9 @@ resources:
     source:
       aws_access_key_id: ((ecr-aws-key))
       aws_secret_access_key: ((ecr-aws-secret))
-      repository: harden-concourse-task
+      repository: general-task
       aws_region: us-gov-west-1
-      tag: ((harden-concourse-task-tag))
+      tag: latest
 
 ############################
 #  RESOURCE TYPES
@@ -176,5 +176,14 @@ resource_types:
       aws_access_key_id: ((ecr_aws_key))
       aws_secret_access_key: ((ecr_aws_secret))
       repository: git-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: registry-image
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: registry-image-resource
       aws_region: us-gov-west-1
       tag: latest


### PR DESCRIPTION
## Changes proposed in this pull request:

- Switches to use the general-task image
- Adds registry-image resource type

## Security considerations

Related to adding hardened containers
