### PR TITLE
don't fail zap task on warnings

### DIFF
--- a/tasks/owasp-zap/definition.py
+++ b/tasks/owasp-zap/definition.py
@@ -17,7 +17,8 @@ class BuildTask(BaseBuildTask):
         output = run([
             'zap-baseline.py',
             '-t', self.args['target'],
-            '-r', filename
+            '-r', filename,
+            '-I'
         ], timeout=900, capture_output=True)
 
         # regex test on output for count


### PR DESCRIPTION
## Changes proposed in this pull request:
- don't fail zap task on warnings
- see the `-I` flag at https://www.zaproxy.org/docs/docker/baseline-scan/#usage

## security considerations
None