### PR TITLE
fix: Add self to BaseBuildTask set_encryption_key method

### DIFF
--- a/common/lib/task.py
+++ b/common/lib/task.py
@@ -49,7 +49,7 @@ class BaseBuildTask:
             if k != 'params':
                 self.args[k] = decrypt(v, self.encryption_key)
 
-    def set_encryption_key():
+    def set_encryption_key(self):
         deploy_env = os.getenv("DEPLOY_ENV")
         vcap_services = json.loads(os.getenv("VCAP_SERVICES", "{}"))
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fix `set_encryption_key` method for `BaseBuildTask` to add `self` argument

## security considerations
None
