### PR TITLE
Release 0.1.4

### DIFF
--- a/.cz.json
+++ b/.cz.json
@@ -1,0 +1,47 @@
+{
+  "commitizen": {
+    "name": "cz_customize",
+    "version_scheme": "semver",
+    "version_provider": "scm",
+    "update_changelog_on_bump": true,
+    "major_version_zero": false,
+    "bump_message": "chore: release $new_version",
+    "gpg_sign": true,
+    "changelog_incremental": true,
+    "customize": {
+      "message_template": "{{change_type}}:{% if show_message %} {{message}}{% endif %}",
+      "example": "feat: this feature enable customize through config file",
+      "schema": "<type>: <body>",
+      "schema_pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w \\-'])+([\\s\\S]*)",
+      "bump_pattern": "^(.+!|BREAKING CHANGE|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\-\\.]+\\))?:",
+      "bump_map": {
+          ".+!": "MAJOR",
+          "BREAKING CHANGE": "MAJOR",
+          "feat": "MINOR",
+          "fix": "PATCH",
+          "chore": "PATCH",
+          "docs": "PATCH",
+          "perf": "PATCH",
+          "refactor": "PATCH",
+          "revert": "MINOR",
+          "style": "PATCH",
+          "test": "PATCH"
+      },
+      "change_type_order": ["Breaking Changes", "Added", "Fixed", "Performance", "Reverted", "Maintenance", "Documentation"],
+      "commit_parser": "^((?P<change_type>chore|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE)(?:\\((?P<scope>[^()\r\n]*)\\)|\\()?(?P<breaking>!)?|\\w+!):\\s(?P<message>.*)?",
+      "changelog_pattern": "^(.+!|BREAKING CHANGE|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\-\\.]+\\))?:",
+      "change_type_map": {
+        "BREAKING CHANGE": "Breaking Changes",
+        "chore": "Maintenance",
+        "docs": "Documentation",
+        "feat": "Added",
+        "fix": "Fixed",
+        "perf": "Performance",
+        "refactor": "Maintenance",
+        "revert": "Reverted",
+        "style": "Maintenance",
+        "test": "Maintenance"
+      }
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,62 @@
+## 0.1.4 (2024-06-25)
+
+### Maintenance
+
+- update pipeline
+
+## 0.1.3 (2024-05-28)
+
+### Added
+
+- Decrypt params and args values passed to build task #4509
+
+### Fixed
+
+- Add self to BaseBuildTask set_encryption_key method
+
+### Maintenance
+
+- container hardening
+
+## 0.1.2 (2024-04-23)
+
+### Maintenance
+
+- better logging, fix a11y error state
+
+## 0.1.1 (2024-04-17)
+
+### Added
+
+- better vulnerability scan
+
+### Maintenance
+
+- better issue count for vulnerability scan, error handling
+
+## 0.1.0 (2024-04-10)
+
+### Added
+
+- deploy to production space (#25)
+- add issue counts
+- add accessibility scan
+- initial implementation of zap scan task
+
+### Fixed
+
+- zap report name
+- don't fail zap task on warnings
+
+### Maintenance
+
+- use a separate cf space for build tasks
+- **ci**: add tests to ci
+- add tests
+- add error handling
+- **ci**: update staging image repo resource
+- remove extra cf-image from pipelines
+- **ci**: Switch to general-task and registry-image for CI jobs
+- add staging pipeline (#8)
+- Update resource types to use hardened images (#6)
+- implement per-task build pattern (#4)

--- a/ci/pipeline-dev.yml
+++ b/ci/pipeline-dev.yml
@@ -1,27 +1,25 @@
 ---
-############################
-#  SHARED
+#@ load("funcs.lib.yml", "slack_hook")
+#@ load("@ytt:data", "data")
+#@ load("@ytt:template", "template")
 
-env-cf: &env-cf
-  CF_API: https://api.fr.cloud.gov
-  CF_USERNAME: ((build-tasks-((deploy-env))-cf-username))
-  CF_PASSWORD: ((build-tasks-((deploy-env))-cf-password))
-  CF_ORG: gsa-18f-federalist
-  CF_SPACE: build-tasks-((deploy-env))
-
-############################
-#  JOBS
+#!  JOBS
 
 jobs:
-
   - name: set-pipeline
-    serial: true
     plan:
       - get: src
         resource: pr
         trigger: true
+      - get: pipeline-tasks
+      - get: general-task
+      - task: init
+        image: general-task
+        file: pipeline-tasks/tasks/init.yml
+        params:
+          PIPELINE_YML: src/ci/pipeline-dev.yml
       - set_pipeline: cf-build-tasks
-        file: src/ci/pipeline-dev.yml
+        file: compiled/set-pipeline.yml
         instance_vars:
           deploy-env: ((deploy-env))
 
@@ -38,10 +36,10 @@ jobs:
           status: pending
           base_context: concourse
           context: test-cf-build-tasks
-      - get: python-image
+      - get: python
       - task: common-test
         file: src/ci/partials/common-test.yml
-        image: python-image
+        image: python
         on_success:
           put: src
           resource: pr
@@ -58,7 +56,6 @@ jobs:
             status: failure
             base_context: concourse
             context: test-cf-build-tasks
-
 
   - name: deploy-((deploy-env))
     plan:
@@ -73,66 +70,50 @@ jobs:
           status: pending
           base_context: concourse
           context: deploy-cf-build-tasks
-      - get: cf-image
+      - get: general-task
       - get: oci-build-task
       - task: ls-tasks
         file: src/ci/partials/ls-tasks.yml
-        image: cf-image
+        image: general-task
       - load_var: build-tasks
         file: src/build-tasks.json
       - across:
-        - var: build-task
-          values: ((.:build-tasks))
-          max_in_flight: 20
+          - var: build-task
+            values: ((.:build-tasks))
+            max_in_flight: 20
         do:
-        - task: build
-          privileged: true
-          image: oci-build-task
-          file: src/ci/partials/build.yml
-          params:
-            BUILD_ARG_TASK_FOLDER: tasks/((.:build-task))
-            BUILD_ARGS_FILE: tasks/((.:build-task))/.env
-            BUILDKIT_SECRETTEXT_UA_TOKEN: ((ua-token))
-            DOCKERFILE: Dockerfile
-        - task: tag-list
-          file: src/ci/partials/tag-list.yml
-          image: cf-image
-          params:
-            TAG: ((.:build-task))-((deploy-env))
-        - put: image-repository
-          params:
-            image: image/image.tar # this might need output_mapping
-            additional_tags: src/tag-list.txt
-        - task: deploy
-          file: src/ci/partials/deploy.yml
-          image: cf-image
-          params:
-            <<: *env-cf
-            CF_APP_NAME: pages-((.:build-task))-task-((deploy-env))
-            CF_MANIFEST: .cloudgov/manifest.yml
-            CF_VARS_FILE: .cloudgov/vars/pages-((deploy-env)).yml
-            IMAGE_REPOSITORY: ../image-repository/repository
-            IMAGE_TAG: ((.:build-task))-((deploy-env))
-            CF_DOCKER_USERNAME: ((ecr-aws-key))
-            CF_DOCKER_PASSWORD: ((ecr-aws-secret))
-          on_failure:
-            put: slack
+          - task: build
+            privileged: true
+            image: oci-build-task
+            file: src/ci/partials/build.yml
             params:
-              text: |
-                :x: FAILED: pages-cf-build-tasks: ((.:build-task)) deployment on ((deploy-env))
-                <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              channel: ((slack-channel))
-              username: ((slack-username))
-              icon_url: ((slack-icon-url))
-          on_success:
-            put: slack
+              BUILD_ARG_TASK_FOLDER: tasks/((.:build-task))
+              BUILD_ARGS_FILE: tasks/((.:build-task))/.env
+              BUILDKIT_SECRETTEXT_UA_TOKEN: ((ua-token))
+              DOCKERFILE: Dockerfile
+          - task: tag-list
+            file: src/ci/partials/tag-list.yml
+            image: general-task
             params:
-              text: |
-                :white_check_mark: SUCCESS: Successfully deployed pages-cf-build-tasks: ((.:build-task)) on ((deploy-env))
-                <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              channel: ((slack-channel))
-              username: ((slack-username))
-              icon_url: ((slack-icon-url))
+              TAG: ((.:build-task))-((deploy-env))
+          - put: image-repository
+            params:
+              image: image/image.tar
+              additional_tags: src/tag-list.txt
+          - task: deploy
+            file: src/ci/partials/deploy.yml
+            image: general-task
+            params:
+              _: #@ template.replace(data.values.env_cf_build_tasks)
+              CF_APP_NAME: pages-((.:build-task))-task-((deploy-env))
+              CF_MANIFEST: .cloudgov/manifest.yml
+              CF_VARS_FILE: .cloudgov/vars/pages-((deploy-env)).yml
+              IMAGE_REPOSITORY: ../image-repository/repository
+              IMAGE_TAG: ((.:build-task))-((deploy-env))
+              CF_DOCKER_USERNAME: ((ecr-aws-key))
+              CF_DOCKER_PASSWORD: ((ecr-aws-secret))
+            on_failure: #@ slack_hook("failure", "((.:build-task)) deployment")
+            on_success: #@ slack_hook("success", "((.:build-task)) deployment")
         on_success:
           put: src
           resource: pr
@@ -150,12 +131,9 @@ jobs:
             base_context: concourse
             context: deploy-cf-build-tasks
 
-
-############################
-#  RESOURCES
+#!  RESOURCES
 
 resources:
-
   - name: pr
     type: pull-request
     check_every: 1m
@@ -166,11 +144,6 @@ resources:
       disable_forks: true
       ignore_drafts: false
 
-  - name: slack
-    type: slack-notification
-    source:
-      url: ((slack-webhook-url))
-
   - name: image-repository
     type: registry-image
     source:
@@ -178,63 +151,18 @@ resources:
       aws_secret_access_key: ((ecr-aws-secret))
       repository: pages-cf-build-tasks
       aws_region: us-gov-west-1
-      tag_regex: '*-((deploy-env))'
+      tag_regex: "*-((deploy-env))"
 
-  - name: cf-image
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr-aws-key))
-      aws_secret_access_key: ((ecr-aws-secret))
-      repository: general-task
-      aws_region: us-gov-west-1
-      tag: latest
-
-  - name: python-image
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr-aws-key))
-      aws_secret_access_key: ((ecr-aws-secret))
-      repository: pages-python-v3.11
-      aws_region: us-gov-west-1
-      tag: latest
-
+  - name: slack
+  - name: general-task
+  - name: pipeline-tasks
+  - name: python
   - name: oci-build-task
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr-aws-key))
-      aws_secret_access_key: ((ecr-aws-secret))
-      repository: oci-build-task
-      aws_region: us-gov-west-1
-      tag: latest
 
-############################
-#  RESOURCE TYPES
+#! RESOURCE TYPES
 
 resource_types:
-
   - name: slack-notification
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: slack-notification-resource
-      aws_region: us-gov-west-1
-      tag: latest
-
   - name: pull-request
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: github-pr-resource
-      aws_region: us-gov-west-1
-      tag: latest
-
   - name: registry-image
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: registry-image-resource
-      aws_region: us-gov-west-1
-      tag: latest
+  - name: git

--- a/ci/pipeline-production.yml
+++ b/ci/pipeline-production.yml
@@ -1,27 +1,25 @@
 ---
-############################
-#  SHARED
+#@ load("funcs.lib.yml", "slack_hook")
+#@ load("@ytt:data", "data")
+#@ load("@ytt:template", "template")
 
-env-cf: &env-cf
-  CF_API: https://api.fr.cloud.gov
-  CF_USERNAME: ((build-tasks-((deploy-env))-cf-username))
-  CF_PASSWORD: ((build-tasks-((deploy-env))-cf-password))
-  CF_ORG: gsa-18f-federalist
-  CF_SPACE: build-tasks-((deploy-env))
-
-############################
-#  JOBS
+#!  JOBS
 
 jobs:
-
   - name: set-pipeline
-    serial: true
     plan:
       - get: src
         resource: src-((deploy-env))-tagged
         trigger: true
+      - get: pipeline-tasks
+      - get: general-task
+      - task: init
+        image: general-task
+        file: pipeline-tasks/tasks/init.yml
+        params:
+          PIPELINE_YML: src/ci/pipeline-staging.yml
       - set_pipeline: cf-build-tasks
-        file: src/ci/pipeline-production.yml
+        file: compiled/set-pipeline.yml
         instance_vars:
           deploy-env: ((deploy-env))
 
@@ -31,74 +29,65 @@ jobs:
         resource: src-((deploy-env))-tagged
         trigger: true
         passed: [set-pipeline]
-      - get: cf-image
+      - get: general-task
       - get: oci-build-task
-      - get: python-image
+      - get: python
       - task: common-test
         file: src/ci/partials/common-test.yml
-        image: python-image
+        image: python
       - task: ls-tasks
         file: src/ci/partials/ls-tasks.yml
-        image: cf-image
+        image: general-task
       - load_var: build-tasks
         file: src/build-tasks.json
       - across:
-        - var: build-task
-          values: ((.:build-tasks))
-          max_in_flight: 20
+          - var: build-task
+            values: ((.:build-tasks))
+            max_in_flight: 20
         do:
-        - task: build
-          privileged: true
-          image: oci-build-task
-          file: src/ci/partials/build.yml
-          params:
-            BUILD_ARG_TASK_FOLDER: tasks/((.:build-task))
-            BUILD_ARGS_FILE: tasks/((.:build-task))/.env
-            BUILDKIT_SECRETTEXT_UA_TOKEN: ((ua-token))
-            DOCKERFILE: Dockerfile
-        - task: tag-list
-          file: src/ci/partials/tag-list.yml
-          image: cf-image
-          params:
-            TAG: ((.:build-task))-((deploy-env))
-        - put: image-repository
-          params:
-            image: image/image.tar # this might need output_mapping
-            additional_tags: src/tag-list.txt
-        - task: deploy
-          file: src/ci/partials/deploy.yml
-          image: cf-image
-          params:
-            <<: *env-cf
-            CF_APP_NAME: pages-((.:build-task))-task-((deploy-env))
-            CF_MANIFEST: .cloudgov/manifest.yml
-            CF_VARS_FILE: .cloudgov/vars/pages-((deploy-env)).yml
-            IMAGE_REPOSITORY: ../image-repository/repository
-            IMAGE_TAG: ((.:build-task))-((deploy-env))
-            CF_DOCKER_USERNAME: ((ecr-aws-key))
-            CF_DOCKER_PASSWORD: ((ecr-aws-secret))
-          on_failure:
-            put: slack
+          - task: build
+            privileged: true
+            image: oci-build-task
+            file: src/ci/partials/build.yml
             params:
-              text: |
-                :x: FAILED: pages-cf-build-tasks: ((.:build-task)) deployment on ((deploy-env))
-                <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              channel: ((slack-channel))
-              username: ((slack-username))
-              icon_url: ((slack-icon-url))
-          on_success:
-            put: slack
+              BUILD_ARG_TASK_FOLDER: tasks/((.:build-task))
+              BUILD_ARGS_FILE: tasks/((.:build-task))/.env
+              BUILDKIT_SECRETTEXT_UA_TOKEN: ((ua-token))
+              DOCKERFILE: Dockerfile
+          - task: tag-list
+            file: src/ci/partials/tag-list.yml
+            image: general-task
             params:
-              text: |
-                :white_check_mark: SUCCESS: Successfully deployed pages-cf-build-tasks: ((.:build-task)) on ((deploy-env))
-                <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              channel: ((slack-channel))
-              username: ((slack-username))
-              icon_url: ((slack-icon-url))
+              TAG: ((.:build-task))-((deploy-env))
+          - put: image-repository
+            params:
+              image: image/image.tar
+              additional_tags: src/tag-list.txt
+          - task: deploy
+            file: src/ci/partials/deploy.yml
+            image: general-task
+            params:
+              _: #@ template.replace(data.values.env_cf_build_tasks)
+              CF_APP_NAME: pages-((.:build-task))-task-((deploy-env))
+              CF_MANIFEST: .cloudgov/manifest.yml
+              CF_VARS_FILE: .cloudgov/vars/pages-((deploy-env)).yml
+              IMAGE_REPOSITORY: ../image-repository/repository
+              IMAGE_TAG: ((.:build-task))-((deploy-env))
+              CF_DOCKER_USERNAME: ((ecr-aws-key))
+              CF_DOCKER_PASSWORD: ((ecr-aws-secret))
+            on_failure: #@ slack_hook("failure", "((.:build-task)) deployment")
+            on_success: #@ slack_hook("success", "((.:build-task)) deployment")
 
+  - name: release
+    plan:
+      - get: src
+        resource: src-((deploy-env))-tagged
+        params: { depth: 1 }
+        trigger: true
+        passed: [deploy-((deploy-env))]
+      -  #@ template.replace(data.values.release_steps)
 
-############################
-#  RESOURCES
+#!  RESOURCES
 
 resources:
   - name: src-((deploy-env))-tagged
@@ -111,11 +100,6 @@ resources:
       tag_filter: 0.*.*
       fetch_tags: true
 
-  - name: slack
-    type: slack-notification
-    source:
-      url: ((slack-webhook-url))
-
   - name: image-repository
     type: registry-image
     source:
@@ -123,63 +107,25 @@ resources:
       aws_secret_access_key: ((ecr-aws-secret))
       repository: pages-cf-build-tasks
       aws_region: us-gov-west-1
-      tag_regex: '*-((deploy-env))'
+      tag_regex: "*-((deploy-env))"
 
-  - name: cf-image
-    type: registry-image
+  - name: pages-release
+    type: github-release
     source:
-      aws_access_key_id: ((ecr-aws-key))
-      aws_secret_access_key: ((ecr-aws-secret))
-      repository: general-task
-      aws_region: us-gov-west-1
-      tag: latest
+      owner: cloud-gov
+      repository: pages-cf-build-tasks
+      access_token: ((gh-access-token))
 
-  - name: python-image
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr-aws-key))
-      aws_secret_access_key: ((ecr-aws-secret))
-      repository: pages-python-v3.11
-      aws_region: us-gov-west-1
-      tag: latest
-
+  - name: slack
+  - name: pipeline-tasks
+  - name: general-task
+  - name: python
   - name: oci-build-task
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr-aws-key))
-      aws_secret_access_key: ((ecr-aws-secret))
-      repository: oci-build-task
-      aws_region: us-gov-west-1
-      tag: latest
 
-############################
-#  RESOURCE TYPES
+#!  RESOURCE TYPES
 
 resource_types:
-
   - name: slack-notification
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: slack-notification-resource
-      aws_region: us-gov-west-1
-      tag: latest
-
   - name: git
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: git-resource
-      aws_region: us-gov-west-1
-      tag: latest
-
   - name: registry-image
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: registry-image-resource
-      aws_region: us-gov-west-1
-      tag: latest
+  - name: github-release

--- a/ci/pipeline-staging.yml
+++ b/ci/pipeline-staging.yml
@@ -1,29 +1,38 @@
 ---
-############################
-#  SHARED
+#@ load("funcs.lib.yml", "slack_hook")
+#@ load("@ytt:data", "data")
+#@ load("@ytt:template", "template")
 
-env-cf: &env-cf
-  CF_API: https://api.fr.cloud.gov
-  CF_USERNAME: ((build-tasks-((deploy-env))-cf-username))
-  CF_PASSWORD: ((build-tasks-((deploy-env))-cf-password))
-  CF_ORG: gsa-18f-federalist
-  CF_SPACE: build-tasks-((deploy-env))
-
-############################
-#  JOBS
+#!  JOBS
 
 jobs:
-
   - name: set-pipeline
-    serial: true
     plan:
       - get: src
         resource: src-((deploy-env))
         trigger: true
+      - get: pipeline-tasks
+      - get: general-task
+      - task: init
+        image: general-task
+        file: pipeline-tasks/tasks/init.yml
+        params:
+          PIPELINE_YML: src/ci/pipeline-staging.yml
       - set_pipeline: cf-build-tasks
-        file: src/ci/pipeline-staging.yml
+        file: compiled/set-pipeline.yml
         instance_vars:
           deploy-env: ((deploy-env))
+
+  - name: update-release-branch
+    plan:
+      - get: src
+        resource: src-((deploy-env))
+        trigger: true
+      - get: general-task
+      - get: pipeline-tasks
+      - task: update-release-branch
+        image: general-task
+        file: pipeline-tasks/tasks/update-release-branch.yml
 
   - name: deploy-((deploy-env))
     plan:
@@ -31,89 +40,66 @@ jobs:
         resource: src-((deploy-env))
         trigger: true
         passed: [set-pipeline]
-      - get: cf-image
+      - get: general-task
       - get: oci-build-task
-      - get: python-image
+      - get: python
       - task: common-test
         file: src/ci/partials/common-test.yml
-        image: python-image
+        image: python
       - task: ls-tasks
         file: src/ci/partials/ls-tasks.yml
-        image: cf-image
+        image: general-task
       - load_var: build-tasks
         file: src/build-tasks.json
       - across:
-        - var: build-task
-          values: ((.:build-tasks))
-          max_in_flight: 20
+          - var: build-task
+            values: ((.:build-tasks))
+            max_in_flight: 20
         do:
-        - task: build
-          privileged: true
-          image: oci-build-task
-          file: src/ci/partials/build.yml
-          params:
-            BUILD_ARG_TASK_FOLDER: tasks/((.:build-task))
-            BUILD_ARGS_FILE: tasks/((.:build-task))/.env
-            BUILDKIT_SECRETTEXT_UA_TOKEN: ((ua-token))
-            DOCKERFILE: Dockerfile
-        - task: tag-list
-          file: src/ci/partials/tag-list.yml
-          image: cf-image
-          params:
-            TAG: ((.:build-task))-((deploy-env))
-        - put: image-repository
-          params:
-            image: image/image.tar # this might need output_mapping
-            additional_tags: src/tag-list.txt
-        - task: deploy
-          file: src/ci/partials/deploy.yml
-          image: cf-image
-          params:
-            <<: *env-cf
-            CF_APP_NAME: pages-((.:build-task))-task-((deploy-env))
-            CF_MANIFEST: .cloudgov/manifest.yml
-            CF_VARS_FILE: .cloudgov/vars/pages-((deploy-env)).yml
-            IMAGE_REPOSITORY: ../image-repository/repository
-            IMAGE_TAG: ((.:build-task))-((deploy-env))
-            CF_DOCKER_USERNAME: ((ecr-aws-key))
-            CF_DOCKER_PASSWORD: ((ecr-aws-secret))
-          on_failure:
-            put: slack
+          - task: build
+            privileged: true
+            image: oci-build-task
+            file: src/ci/partials/build.yml
             params:
-              text: |
-                :x: FAILED: pages-cf-build-tasks: ((.:build-task)) deployment on ((deploy-env))
-                <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              channel: ((slack-channel))
-              username: ((slack-username))
-              icon_url: ((slack-icon-url))
-          on_success:
-            put: slack
+              BUILD_ARG_TASK_FOLDER: tasks/((.:build-task))
+              BUILD_ARGS_FILE: tasks/((.:build-task))/.env
+              BUILDKIT_SECRETTEXT_UA_TOKEN: ((ua-token))
+              DOCKERFILE: Dockerfile
+          - task: tag-list
+            file: src/ci/partials/tag-list.yml
+            image: general-task
             params:
-              text: |
-                :white_check_mark: SUCCESS: Successfully deployed pages-cf-build-tasks: ((.:build-task)) on ((deploy-env))
-                <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-              channel: ((slack-channel))
-              username: ((slack-username))
-              icon_url: ((slack-icon-url))
+              TAG: ((.:build-task))-((deploy-env))
+          - put: image-repository
+            params:
+              image: image/image.tar
+              additional_tags: src/tag-list.txt
+          - task: deploy
+            file: src/ci/partials/deploy.yml
+            image: general-task
+            params:
+              _: #@ template.replace(data.values.env_cf_build_tasks)
+              CF_APP_NAME: pages-((.:build-task))-task-((deploy-env))
+              CF_MANIFEST: .cloudgov/manifest.yml
+              CF_VARS_FILE: .cloudgov/vars/pages-((deploy-env)).yml
+              IMAGE_REPOSITORY: ../image-repository/repository
+              IMAGE_TAG: ((.:build-task))-((deploy-env))
+              CF_DOCKER_USERNAME: ((ecr-aws-key))
+              CF_DOCKER_PASSWORD: ((ecr-aws-secret))
+            on_failure: #@ slack_hook("failure", "((.:build-task)) deployment")
+            on_success: #@ slack_hook("success", "((.:build-task)) deployment")
 
-
-############################
-#  RESOURCES
+#!  RESOURCES
 
 resources:
-
   - name: src-((deploy-env))
     type: git
     icon: github
     source:
-      uri: https://github.com/cloud-gov/pages-cf-build-tasks.git
+      uri: git@github.com:cloud-gov/pages-cf-build-tasks.git
       branch: main
       commit_verification_keys: ((cloud-gov-pages-gpg-keys))
-
-  - name: slack
-    type: slack-notification
-    source:
-      url: ((slack-webhook-url))
+      private_key: ((pages-gpg-operations-github-sshkey.private_key))
 
   - name: image-repository
     type: registry-image
@@ -122,63 +108,17 @@ resources:
       aws_secret_access_key: ((ecr-aws-secret))
       repository: pages-cf-build-tasks
       aws_region: us-gov-west-1
-      tag_regex: '*-((deploy-env))'
+      tag_regex: "*-((deploy-env))"
 
-  - name: cf-image
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr-aws-key))
-      aws_secret_access_key: ((ecr-aws-secret))
-      repository: general-task
-      aws_region: us-gov-west-1
-      tag: latest
-
-  - name: python-image
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr-aws-key))
-      aws_secret_access_key: ((ecr-aws-secret))
-      repository: pages-python-v3.11
-      aws_region: us-gov-west-1
-      tag: latest
-
+  - name: slack
+  - name: pipeline-tasks
+  - name: general-task
+  - name: python
   - name: oci-build-task
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr-aws-key))
-      aws_secret_access_key: ((ecr-aws-secret))
-      repository: oci-build-task
-      aws_region: us-gov-west-1
-      tag: latest
 
-############################
-#  RESOURCE TYPES
+#!  RESOURCE TYPES
 
 resource_types:
-
   - name: slack-notification
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: slack-notification-resource
-      aws_region: us-gov-west-1
-      tag: latest
-
   - name: git
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: git-resource
-      aws_region: us-gov-west-1
-      tag: latest
-
   - name: registry-image
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: registry-image-resource
-      aws_region: us-gov-west-1
-      tag: latest


### PR DESCRIPTION
## :robot: This is an automated release PR
chore: release 0.1.4
tag to create: 0.1.4
increment detected: PATCH

## 0.1.4 (2024-06-25)

### Maintenance

- update pipeline

## 0.1.3 (2024-05-28)

### Added

- Decrypt params and args values passed to build task #4509

### Fixed

- Add self to BaseBuildTask set_encryption_key method

### Maintenance

- container hardening

## 0.1.2 (2024-04-23)

### Maintenance

- better logging, fix a11y error state

## 0.1.1 (2024-04-17)

### Added

- better vulnerability scan

### Maintenance

- better issue count for vulnerability scan, error handling

## 0.1.0 (2024-04-10)

### Added

- deploy to production space (#25)
- add issue counts
- add accessibility scan
- initial implementation of zap scan task

### Fixed

- zap report name
- don't fail zap task on warnings

### Maintenance

- use a separate cf space for build tasks
- **ci**: add tests to ci
- add tests
- add error handling
- **ci**: update staging image repo resource
- remove extra cf-image from pipelines
- **ci**: Switch to general-task and registry-image for CI jobs
- add staging pipeline (#8)
- Update resource types to use hardened images (#6)
- implement per-task build pattern (#4)
## security considerations
Noted in individual PRs
