### PR TITLE
chore: Refactor zap and a11y tasks to upload just JSON results

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -108,6 +108,8 @@ jobs:
             params:
               image: image/image.tar
               additional_tags: src/tag-list.txt
+            get_params:
+              skip_download: true
           - task: deploy
             file: src/ci/partials/deploy.yml
             image: general-task

--- a/common/lib/task.py
+++ b/common/lib/task.py
@@ -88,17 +88,20 @@ class BaseBuildTask:
             "message": err
         })
 
-    def upload_file(self):
+    def upload_results(self):
         """upload file to S3"""
-        filename = self.results["artifact"]
-        base = os.path.basename(filename)
-        self.key = f'_tasks/artifacts/{self.task_id}/{base}'
+        results_dir = self.results["artifact"]
+        self.key = f'_tasks/artifacts/{self.task_id}/'
 
-        self.s3_client.upload_file(
-            Filename=filename,
-            Bucket=self.bucket,
-            Key=self.key,
-        )
+        for filename in os.listdir(results_dir):
+            base = os.path.basename(filename)
+            s3key = f'{self.key}{base}'
+
+            self.s3_client.upload_file(
+                Filename=f'{results_dir}/{filename}',
+                Bucket=self.bucket,
+                Key=s3key,
+            )
 
     def handler():
         raise NotImplementedError

--- a/common/main.py
+++ b/common/main.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
         try:
             task.status_start()
             task.results = task.handler()
-            task.upload_file()
+            task.upload_results()
             task.status_end()
         except NotImplementedError:
             """operator didn't write a handler"""

--- a/tasks/a11y/definition.py
+++ b/tasks/a11y/definition.py
@@ -33,8 +33,7 @@ class BuildTask(BaseBuildTask):
             cf.write(config)
 
         results_dir = '/build-task/results'
-        reports_dir = '/build-task/reports'
-        templates_dir = '/build-task/reporter/templates'
+        output_dir = '/build-task/output'
         os.makedirs(results_dir, exist_ok=True)
 
         # crawl
@@ -66,16 +65,13 @@ class BuildTask(BaseBuildTask):
                 with open(os.path.join(results_dir, str(idx)), 'w') as f:
                     json.dump([dict(url=url, error=True)], f)
 
-        # report
         output = run([
             'node',
             'build-task/reporter/generate-report.js',
             '--inputDir',
             results_dir,
             '--outputDir',
-            reports_dir,
-            '--templateDir',
-            templates_dir,
+            output_dir,
             '--target',
             target,
             '--buildId',
@@ -84,6 +80,7 @@ class BuildTask(BaseBuildTask):
             config_file
         ], capture_output=True)
 
+        # Keeping until we remove report generation
         # regex test on output for count
         summary_regex = r'Issue Count: (\d+)'
         match = re.search(summary_regex, output.stdout)
@@ -92,12 +89,8 @@ class BuildTask(BaseBuildTask):
         except Exception:
             count = 0
 
-        # bundle
-        filename = f'/accessibility-scan-for-{owner}-{repository}-{buildid}'  # noqa: E501
-        shutil.make_archive(filename, 'zip', reports_dir)
-
         return dict(
-            artifact=f'{filename}.zip',
+            artifact=output_dir,
             message=None,
             count=count,
         )

--- a/tasks/a11y/reporter/README.md
+++ b/tasks/a11y/reporter/README.md
@@ -5,10 +5,96 @@
 Creates an HTML report from Axe results listing violations, passes, incomplete
 and incompatible results.
 
-Given an `inputDir` containing JSON files from [@axe-core/cli](https://www.npmjs.com/package/@axe-core/cli) for a given `target` and a `templateDir` containing `.ejs` files, the following command creates matching HTML reports in an `outputDir`.
+Given an `inputDir` containing JSON files from [@axe-core/cli](https://www.npmjs.com/package/@axe-core/cli) for a given `target`, the following command creates matching JSON reports in an `outputDir`.
 
 ```sh
 
-node generate-report.js --inputDir results --outputDir reports --templateDir templates --target https://example.gov
+node generate-report.js --inputDir results --outputDir reports --target https://example.gov
 
+```
+
+## Output
+
+The scan results are stored as JSON objects in the site's S3 bucket under the task id's key.
+The file structure consist of an `index.json` that is used to summarize all of the identified violated rules, list the violations, and provide a path to the results page.
+
+```json
+// index
+{
+  // The site's base url
+  "baseurl": "https://example.gov",
+  // Total number of site pages with rule violations
+  "totalPageCount": 8,
+  // Total Violations
+  "totalViolationsCount": 11,
+  // List of the rules that are violated across the site
+  "violatedRules": [
+    {
+      // Violation ID
+      "id": "rules-x-violated",
+      // Violation impact level
+      "impact": "serious",
+      // Description of violation
+      "description": "This rule x expects this to be y.",
+      // Help text to fix the violation
+      "help": "Update x to be more like y",
+      // List of nodes violating the rule in the site
+      "nodes": [{}],
+      // Error color
+      "color": "error-dark",
+      // Error order
+      "order": 1,
+      // Total number of occurences the rule was violated
+      "total": 8,
+      // If the violation rule should be ignored
+      "ignore": false,
+      // The source used to ignore the rule
+      "ignoreSource": ""
+    }
+  ],
+  "currentPage": 8,
+  // List of all of the report pages with information summarrized the page's violations
+  "reportPages": [
+    {
+      // The ouput scan result page
+      // /sites/:site_id/builds/:build_id/scans/:task_id/axe-results-12345
+      "path": "axe-results-12345",
+      // The url of the site's page with the reported violations
+      "absoluteURL": "https://test.example.gov/page/",
+      // Timestamp of the test
+      "timestamp": "YYYY-MM-DDTHH:ss:SSS",
+      // Total violations found on site's page
+      "violationsCount": 2,
+      // Summary of the violation types an count
+      "groupedViolationsCounts": [{ "name": "serious", "count": 2 }],
+      // Summary of the violation types an count
+      "indexPills": [{ "name": "serious", "count": 2 }],
+      "moreCount": 0
+    }
+  ]
+}
+
+```
+
+The additional results generated are identifying each page of the site that has at least one violation identitfied.
+
+```json
+// axe-result-12345
+{
+    // The url of the site's page with the reported violations
+    "url": "https://test.example.gov/page/",
+    // Timestamp of the test
+    "timestamp": "YYYY-MM-DDTHH:ss:SSS",
+    // An array of rules tested that passed on the page
+    "passes": [],
+    // An object grouping violations based their violation type
+    // Each violation type is an array of the violations identified
+    "groupedViolations": {
+      "critical": [...],
+      "serious": [...],
+      ...
+    },
+    // Total number of violations found on pages
+    "violationsCount": 2
+}
 ```

--- a/tasks/a11y/reporter/package.json
+++ b/tasks/a11y/reporter/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "ejslint templates/*",
     "build": "node generate-report.js",
-    "watch": "ejslint templates/* && node --watch-path=./templates --watch-path=./generate-report.js  generate-report.js --inputDir results --outputDir reports --templateDir templates --target https://example.gov --buildId 123456"
+    "watch": "ejslint templates/* && node --watch-path=./templates --watch-path=./generate-report.js  generate-report.js --inputDir results --outputDir reports --target https://example.gov --buildId 123456"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",

--- a/tasks/owasp-zap/definition.py
+++ b/tasks/owasp-zap/definition.py
@@ -27,8 +27,7 @@ class BuildTask(BaseBuildTask):
             cf.write(config)
 
         tmp_report = 'report.json'
-        templates_dir = '/build-task/reporter/templates'
-
+        output_dir = '/build-task/output'
         filename = f'/zap-scan-for-{owner}-{repository}-{buildid}.html'
 
         output = run([
@@ -45,10 +44,8 @@ class BuildTask(BaseBuildTask):
             'build-task/reporter/generate-report.js',
             '--input',
             f'/zap/wrk/{tmp_report}',
-            '--output',
-            filename,
-            '--templateDir',
-            templates_dir,
+            '--outputDir',
+            output_dir,
             '--target',
             target,
             '--buildId',
@@ -57,6 +54,7 @@ class BuildTask(BaseBuildTask):
             config_file
         ], capture_output=True)
 
+        # Keeping until we remove report generation
         # regex test on output for count
         summary_regex = r'Issue Count: (\d+)'
         match = re.search(summary_regex, output.stdout)
@@ -66,7 +64,7 @@ class BuildTask(BaseBuildTask):
             count = 0
 
         return dict(
-            artifact=filename,
+            artifact=output_dir,
             message=None,
             count=count,
         )

--- a/tasks/owasp-zap/reporter/README.md
+++ b/tasks/owasp-zap/reporter/README.md
@@ -2,10 +2,10 @@
 
 Creates an HTML report from ZAP vulnerability scan
 
-Given an `input` JSON file for a given `target` and a `templateDir` containing `.ejs` files, the following command creates a matching HTML report`.
+Given an `input` JSON file for a given `target`, the following command creates a matching JSON report`.
 
 ```sh
 
-node generate-report.js --input results.json --templateDir templates --target https://example.gov
+node generate-report.js --input results.json --target https://example.gov
 
 ```

--- a/tasks/owasp-zap/reporter/package.json
+++ b/tasks/owasp-zap/reporter/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "ejslint templates/*",
     "build": "node generate-report.js",
-    "watch": "ejslint templates/* && node --watch-path=./templates --watch-path=./generate-report.js generate-report.js --input report.json --output report.html --templateDir templates --target https://example.gov --buildId 123456"
+    "watch": "ejslint templates/* && node --watch-path=./templates --watch-path=./generate-report.js generate-report.js --input report.json --output report.html --target https://example.gov --buildId 123456"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",


### PR DESCRIPTION
## Changes proposed in this pull request:

- Refactors the zap and a11y scans to upload the scan output json to s3
- Updates the base task method name to `upload_results`
- The `upload_results` task uploads all of the files in the output directory to s3

## security considerations
none