### PR TITLE
use the correct variable name on second pass deduplication

### DIFF
--- a/tasks/owasp-zap/reporter/generate-report.js
+++ b/tasks/owasp-zap/reporter/generate-report.js
@@ -69,8 +69,8 @@ function cleanAlerts (alerts, config) {
       const test = alert.instances.some(i => i.ignore) && !alert.instances.every(i => i.ignore);
       const alertArray = test
         ? [
-          { ...alert, instances: instances.filter(i => i.ignore), ignore: true },
-          { ...alert, instances: instances.filter(i => !i.ignore), ignore: false },
+          { ...alert, instances: alert.instances.filter(i => i.ignore), ignore: true },
+          { ...alert, instances: alert.instances.filter(i => !i.ignore), ignore: false },
         ]
         : [alert]
       return agg.concat(alertArray)


### PR DESCRIPTION
## Changes proposed in this pull request:
-  use the correct variable name on second pass deduplication of ignored findings

## security considerations
None