### PR TITLE
chore: Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cloud-gov/pages-ops


### PR DESCRIPTION
Closes https://github.com/cloud-gov/product/issues/3396

## Changes proposed in this pull request:
- Pages Ops owns it

## security considerations
Its been owned
